### PR TITLE
Unlock Drupal 8.7.0 so it can run on drupal.org test infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_script:
   - mysql -e 'create database cas_mock_server'
 
   # Install Composer dependencies.
-  - composer install
+  - composer require drupal/core:~8.6.0
 
   # Export web server URL for browser tests.
   - export SIMPLETEST_BASE_URL=http://localhost:80

--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ This module provides a mocked CAS server for testing purposes.
 Disclaimer
 ----------
 
-This is an unofficial branch (`8.x-0.x`) which supports PHP 5.6 and Drupal 8.6.
-It is not actively maintained. You can submit patches but they will be reviewed
-with low priority. For a better developer experience require `"php": ">=7.1"` in
-your project and use the official `8.x-1.x` branch. 
+**The `8.x-0.x` branch only supports PHP 5.6 on Drupal 8.6**
+
+It is only provided for backwards compatibility reasons and is not actively
+maintained. For a better developer experience require `"php": ">=7.1"` and
+`"drupal/core": "^8.7.0"` in your project and use the official `8.x-1.x`
+branch.
 
 This is purely intended for testing. Under no circumstances should this module
 be enabled on a production environment.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   },
   "require": {
     "drupal/cas": "~1.5",
-    "drupal/core": "~8.6.0"
+    "drupal/core": "~8.6.0|~8.7.0"
   },
   "require-dev": {
     "composer/installers": "^1.6",


### PR DESCRIPTION
Drupal 8.7 can not be installed on PHP 5.6 so we cannot run our Behat tests on it. The drupal.org test runner still supports this combination so we unlock the version dependency for this purpose only. It is unsupported.