### PR TITLE
Issue #3153064: Tests are failing with CAS 8.x-1.7

### DIFF
--- a/tests/src/Kernel/ServiceResponseAlterTest.php
+++ b/tests/src/Kernel/ServiceResponseAlterTest.php
@@ -38,6 +38,7 @@ class ServiceResponseAlterTest extends KernelTestBase {
     'cas_mock_server_test',
     'externalauth',
     'system',
+    'user',
   ];
 
   /**


### PR DESCRIPTION
Fixes https://www.drupal.org/project/cas_mock_server/issues/3153064