### PR TITLE
Execute tests on both the highest and lowest Composer dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,8 @@ before_script:
   - mysql -e 'create database cas_mock_server'
 
   # Install Composer dependencies.
-  - test $DEPENDENCIES == "lowest" && COMPOSER_OPTIONS="--prefer-lowest"
-  - composer install $COMPOSER_OPTIONS
+  - test $DEPENDENCIES == "lowest" && COMPOSER_OPTIONS="--prefer-lowest" || true
+  - composer update $COMPOSER_OPTIONS
 
   # Export web server URL for browser tests.
   - export SIMPLETEST_BASE_URL=http://localhost:80

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,33 +6,41 @@ env:
 
 jobs:
   include:
-    - php: 7.1
+    - name: 'Drupal 8 on PHP 7.1'
+      php: 7.1
       env: TEST_SUITE=PHPUnit DEPENDENCIES=lowest
-    - php: 7.1
+    - name: 'Testing Behat with Drupal 8 on PHP 7.1'
+      php: 7.1
       env: TEST_SUITE=Behat DEPENDENCIES=lowest
     - php: 7.2
       env: TEST_SUITE=PHPUnit
-    - php: 7.2
+    - name: 'Testing PHPUnit with Drupal 8 on PHP 7.2'
+      php: 7.2
       env: TEST_SUITE=PHPUnit DEPENDENCIES=lowest
     - php: 7.2
       env: TEST_SUITE=Behat
-    - php: 7.2
+    - name: 'Testing Behat with Drupal 8 on PHP 7.2'
+      php: 7.2
       env: TEST_SUITE=Behat DEPENDENCIES=lowest
     - php: 7.3
       env: TEST_SUITE=PHPUnit
-    - php: 7.3
+    - name: 'Testing PHPUnit with Drupal 8 on PHP 7.3'
+      php: 7.3
       env: TEST_SUITE=PHPUnit DEPENDENCIES=lowest
     - php: 7.3
       env: TEST_SUITE=Behat
-    - php: 7.3
+    - name: 'Testing Behat with Drupal 8 on PHP 7.3'
+      php: 7.3
       env: TEST_SUITE=Behat DEPENDENCIES=lowest
     - php: 7.4
       env: TEST_SUITE=PHPUnit
-    - php: 7.4
+    - name: 'Testing PHPUnit with Drupal 8 on PHP 7.4'
+      php: 7.4
       env: TEST_SUITE=PHPUnit DEPENDENCIES=lowest
     - php: 7.4
       env: TEST_SUITE=Behat
-    - php: 7.4
+    - name: 'Testing Behat with Drupal 8 on PHP 7.4'
+      php: 7.4
       env: TEST_SUITE=Behat DEPENDENCIES=lowest
     - php: 7.4
       env: TEST_SUITE=PHP_CodeSniffer

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 language: php
 
-php:
-  - 7.1
-  - 7.2
-  - 7.3
-  - 7.4
-
 env:
   global:
     - COMPOSER_MEMORY_LIMIT=2G

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,26 @@ env:
     - TEST_SUITE=Behat
     - TEST_SUITE=PHPUnit
     - TEST_SUITE=PHP_CodeSniffer
+    - DEPENDENCIES=lowest
+    - DEPENDENCIES=highest
 
 # Only run the coding standards check once.
 matrix:
   exclude:
     - php: 7.1
-      env: TEST_SUITE=PHP_CodeSniffer
+      env: TEST_SUITE=PHP_CodeSniffer DEPENDENCIES=lowest
+    - php: 7.1
+      env: TEST_SUITE=PHP_CodeSniffer DEPENDENCIES=highest
     - php: 7.2
-      env: TEST_SUITE=PHP_CodeSniffer
+      env: TEST_SUITE=PHP_CodeSniffer DEPENDENCIES=lowest
+    - php: 7.2
+      env: TEST_SUITE=PHP_CodeSniffer DEPENDENCIES=highest
     - php: 7.3
-      env: TEST_SUITE=PHP_CodeSniffer
+      env: TEST_SUITE=PHP_CodeSniffer DEPENDENCIES=lowest
+    - php: 7.3
+      env: TEST_SUITE=PHP_CodeSniffer DEPENDENCIES=highest
+    - php: 7.4
+      env: TEST_SUITE=PHP_CodeSniffer DEPENDENCIES=lowest
 
 services:
   - mysql
@@ -59,7 +69,8 @@ before_script:
   - mysql -e 'create database cas_mock_server'
 
   # Install Composer dependencies.
-  - composer install
+  - test $DEPENDENCIES == "lowest" && COMPOSER_OPTIONS="--prefer-lowest"
+  - composer install $COMPOSER_OPTIONS
 
   # Export web server URL for browser tests.
   - export SIMPLETEST_BASE_URL=http://localhost:80

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,62 +11,62 @@ jobs:
   include:
     - name: 'PHPUnit with Drupal 8 on PHP 7.1'
       php: 7.1
-      env: TEST_SUITE=PHPUnit DEPENDENCIES=lowest
+      env: TEST_SUITE=PHPUnit COMPOSER_OPTIONS=--prefer-lowest
     - name: 'Behat with Drupal 8 on PHP 7.1'
       php: 7.1
-      env: TEST_SUITE=Behat DEPENDENCIES=lowest
+      env: TEST_SUITE=Behat COMPOSER_OPTIONS=--prefer-lowest
     - name: 'PHPUnit with Drupal 9 on PHP 7.2'
       php: 7.2
       env: TEST_SUITE=PHPUnit
     - name: 'PHPUnit with Drupal 8 on PHP 7.2'
       php: 7.2
-      env: TEST_SUITE=PHPUnit DEPENDENCIES=lowest
+      env: TEST_SUITE=PHPUnit COMPOSER_OPTIONS=--prefer-lowest
     - name: 'Behat with Drupal 9 on PHP 7.2'
       php: 7.2
       env: TEST_SUITE=Behat
     - name: 'Behat with Drupal 8 on PHP 7.2'
       php: 7.2
-      env: TEST_SUITE=Behat DEPENDENCIES=lowest
+      env: TEST_SUITE=Behat COMPOSER_OPTIONS=--prefer-lowest
     - name: 'PHPUnit with Drupal 9 on PHP 7.3'
       php: 7.3
       env: TEST_SUITE=PHPUnit
     - name: 'PHPUnit with Drupal 8 on PHP 7.3'
       php: 7.3
-      env: TEST_SUITE=PHPUnit DEPENDENCIES=lowest
+      env: TEST_SUITE=PHPUnit COMPOSER_OPTIONS=--prefer-lowest
     - name: 'Behat with Drupal 9 on PHP 7.3'
       php: 7.3
       env: TEST_SUITE=Behat
     - name: 'Behat with Drupal 8 on PHP 7.3'
       php: 7.3
-      env: TEST_SUITE=Behat DEPENDENCIES=lowest
+      env: TEST_SUITE=Behat COMPOSER_OPTIONS=--prefer-lowest
     - name: 'PHPUnit with Drupal 9 on PHP 7.4'
       php: 7.4
       env: TEST_SUITE=PHPUnit
     - name: 'PHPUnit with Drupal 8 on PHP 7.4'
       php: 7.4
-      env: TEST_SUITE=PHPUnit DEPENDENCIES=lowest
+      env: TEST_SUITE=PHPUnit COMPOSER_OPTIONS=--prefer-lowest
     - name: 'Behat with Drupal 9 on PHP 7.4'
       php: 7.4
       env: TEST_SUITE=Behat
     - name: 'Behat with Drupal 8 on PHP 7.4'
       php: 7.4
-      env: TEST_SUITE=Behat DEPENDENCIES=lowest
+      env: TEST_SUITE=Behat COMPOSER_OPTIONS=--prefer-lowest
     - name: 'PHPUnit with Drupal 9 on PHP 8.0 nightly'
       php: nightly
-      env: TEST_SUITE=PHPUnit
+      env: TEST_SUITE=PHPUnit COMPOSER_OPTIONS=--ignore-platform-reqs
     - name: 'Behat with Drupal 9 on PHP 8.0 nightly'
       php: nightly
-      env: TEST_SUITE=Behat
+      env: TEST_SUITE=Behat COMPOSER_OPTIONS=--ignore-platform-reqs
     - name: 'PHP_CodeSniffer'
       php: 7.4
       env: TEST_SUITE=PHP_CodeSniffer
   allow_failures:
     - name: 'PHPUnit with Drupal 9 on PHP 8.0 nightly'
       php: nightly
-      env: TEST_SUITE=PHPUnit
+      env: TEST_SUITE=PHPUnit COMPOSER_OPTIONS=--ignore-platform-reqs
     - name: 'Behat with Drupal 9 on PHP 8.0 nightly'
       php: nightly
-      env: TEST_SUITE=Behat
+      env: TEST_SUITE=Behat COMPOSER_OPTIONS=--ignore-platform-reqs
 
 cache:
   directories:
@@ -92,7 +92,6 @@ before_script:
   - mysql -e 'create database cas_mock_server'
 
   # Install Composer dependencies.
-  - test $DEPENDENCIES == "lowest" && COMPOSER_OPTIONS="--prefer-lowest" || true
   - composer update $COMPOSER_OPTIONS
 
   # Export web server URL for browser tests.

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,12 @@ jobs:
     - name: 'Behat with Drupal 8 on PHP 7.4'
       php: 7.4
       env: TEST_SUITE=Behat DEPENDENCIES=lowest
+    - name: 'PHPUnit with Drupal 9 on PHP 8.0 nightly'
+      php: nightly
+      env: TEST_SUITE=PHPUnit
+    - name: 'Behat with Drupal 9 on PHP 8.0 nightly'
+      php: nightly
+      env: TEST_SUITE=Behat
     - name: 'PHP_CodeSniffer'
       php: 7.4
       env: TEST_SUITE=PHP_CodeSniffer

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,43 +6,50 @@ env:
 
 jobs:
   include:
-    - name: 'Drupal 8 on PHP 7.1'
+    - name: 'PHPUnit with Drupal 8 on PHP 7.1'
       php: 7.1
       env: TEST_SUITE=PHPUnit DEPENDENCIES=lowest
-    - name: 'Testing Behat with Drupal 8 on PHP 7.1'
+    - name: 'Behat with Drupal 8 on PHP 7.1'
       php: 7.1
       env: TEST_SUITE=Behat DEPENDENCIES=lowest
-    - php: 7.2
+    - name: 'PHPUnit with Drupal 9 on PHP 7.2'
+      php: 7.2
       env: TEST_SUITE=PHPUnit
-    - name: 'Testing PHPUnit with Drupal 8 on PHP 7.2'
+    - name: 'PHPUnit with Drupal 8 on PHP 7.2'
       php: 7.2
       env: TEST_SUITE=PHPUnit DEPENDENCIES=lowest
-    - php: 7.2
+    - name: 'Behat with Drupal 9 on PHP 7.2'
+      php: 7.2
       env: TEST_SUITE=Behat
-    - name: 'Testing Behat with Drupal 8 on PHP 7.2'
+    - name: 'Behat with Drupal 8 on PHP 7.2'
       php: 7.2
       env: TEST_SUITE=Behat DEPENDENCIES=lowest
-    - php: 7.3
+    - name: 'PHPUnit with Drupal 9 on PHP 7.3'
+      php: 7.3
       env: TEST_SUITE=PHPUnit
-    - name: 'Testing PHPUnit with Drupal 8 on PHP 7.3'
+    - name: 'PHPUnit with Drupal 8 on PHP 7.3'
       php: 7.3
       env: TEST_SUITE=PHPUnit DEPENDENCIES=lowest
-    - php: 7.3
+    - name: 'Behat with Drupal 9 on PHP 7.3'
+      php: 7.3
       env: TEST_SUITE=Behat
-    - name: 'Testing Behat with Drupal 8 on PHP 7.3'
+    - name: 'Behat with Drupal 8 on PHP 7.3'
       php: 7.3
       env: TEST_SUITE=Behat DEPENDENCIES=lowest
-    - php: 7.4
+    - name: 'PHPUnit with Drupal 9 on PHP 7.4'
+      php: 7.4
       env: TEST_SUITE=PHPUnit
-    - name: 'Testing PHPUnit with Drupal 8 on PHP 7.4'
+    - name: 'PHPUnit with Drupal 8 on PHP 7.4'
       php: 7.4
       env: TEST_SUITE=PHPUnit DEPENDENCIES=lowest
-    - php: 7.4
+    - name: 'Behat with Drupal 9 on PHP 7.4'
+      php: 7.4
       env: TEST_SUITE=Behat
-    - name: 'Testing Behat with Drupal 8 on PHP 7.4'
+    - name: 'Behat with Drupal 8 on PHP 7.4'
       php: 7.4
       env: TEST_SUITE=Behat DEPENDENCIES=lowest
-    - php: 7.4
+    - name: 'PHP_CodeSniffer'
+      php: 7.4
       env: TEST_SUITE=PHP_CodeSniffer
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,13 @@ jobs:
     - name: 'PHP_CodeSniffer'
       php: 7.4
       env: TEST_SUITE=PHP_CodeSniffer
+  allow_failures:
+    - name: 'PHPUnit with Drupal 9 on PHP 8.0 nightly'
+      php: nightly
+      env: TEST_SUITE=PHPUnit
+    - name: 'Behat with Drupal 9 on PHP 8.0 nightly'
+      php: nightly
+      env: TEST_SUITE=Behat
 
 services:
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 
+services:
+  - mysql
+
 env:
   global:
     - COMPOSER_MEMORY_LIMIT=2G
@@ -65,20 +68,11 @@ jobs:
       php: nightly
       env: TEST_SUITE=Behat
 
-services:
-  - mysql
-
-mysql:
-  database: cas_mock_server
-  username: root
-  encoding: utf8
-
 cache:
   directories:
     - ${HOME}/.composer/cache
 
 before_script:
-
   # Store the current directory for later use in the Drupal installation.
   - MODULE_DIR=$(pwd)
 
@@ -88,9 +82,7 @@ before_script:
   # Install Apache when running Behat tests.
   - if [ ${TEST_SUITE} == "Behat" ]; then ${MODULE_DIR}/tests/travis-ci/install-apache.sh; fi
 
-  # Remove Xdebug as we don't need it and it causes "PHP Fatal error: Maximum
-  # function nesting level of '256' reached."
-  # We also don't care if that file exists or not on PHP 7.
+  # Remove Xdebug.
   - phpenv config-rm xdebug.ini || true
 
   # Make sure Composer is up to date.

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,30 +9,39 @@ php:
 env:
   global:
     - COMPOSER_MEMORY_LIMIT=2G
-  matrix:
-    - TEST_SUITE=Behat
-    - TEST_SUITE=PHPUnit
-    - TEST_SUITE=PHP_CodeSniffer
-    - DEPENDENCIES=lowest
-    - DEPENDENCIES=highest
 
-# Only run the coding standards check once.
-matrix:
-  exclude:
+jobs:
+  include:
     - php: 7.1
-      env: TEST_SUITE=PHP_CodeSniffer DEPENDENCIES=lowest
+      env: TEST_SUITE=PHPUnit DEPENDENCIES=lowest
     - php: 7.1
-      env: TEST_SUITE=PHP_CodeSniffer DEPENDENCIES=highest
+      env: TEST_SUITE=Behat DEPENDENCIES=lowest
     - php: 7.2
-      env: TEST_SUITE=PHP_CodeSniffer DEPENDENCIES=lowest
+      env: TEST_SUITE=PHPUnit
     - php: 7.2
-      env: TEST_SUITE=PHP_CodeSniffer DEPENDENCIES=highest
+      env: TEST_SUITE=PHPUnit DEPENDENCIES=lowest
+    - php: 7.2
+      env: TEST_SUITE=Behat
+    - php: 7.2
+      env: TEST_SUITE=Behat DEPENDENCIES=lowest
     - php: 7.3
-      env: TEST_SUITE=PHP_CodeSniffer DEPENDENCIES=lowest
+      env: TEST_SUITE=PHPUnit
     - php: 7.3
-      env: TEST_SUITE=PHP_CodeSniffer DEPENDENCIES=highest
+      env: TEST_SUITE=PHPUnit DEPENDENCIES=lowest
+    - php: 7.3
+      env: TEST_SUITE=Behat
+    - php: 7.3
+      env: TEST_SUITE=Behat DEPENDENCIES=lowest
     - php: 7.4
-      env: TEST_SUITE=PHP_CodeSniffer DEPENDENCIES=lowest
+      env: TEST_SUITE=PHPUnit
+    - php: 7.4
+      env: TEST_SUITE=PHPUnit DEPENDENCIES=lowest
+    - php: 7.4
+      env: TEST_SUITE=Behat
+    - php: 7.4
+      env: TEST_SUITE=Behat DEPENDENCIES=lowest
+    - php: 7.4
+      env: TEST_SUITE=PHP_CodeSniffer
 
 services:
   - mysql

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -11,7 +11,7 @@ default:
               lastname: Last name
         - Drupal\Tests\cas_mock_server\Context\FeatureContext
       paths:
-        - %paths.base%/tests/features
+        - '%paths.base%/tests/features'
   extensions:
     Drupal\MinkExtension:
       base_url: 'http://localhost:80'

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
     }
   },
   "minimum-stability": "alpha",
+  "prefer-stable": true,
   "suggest": {
     "drupal/config_override_warn": "Shows a warning on the CAS configuration form when the mock server is active."
   },

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
   },
   "require-dev": {
     "composer/installers": "^1.6",
+    "consolidation/robo": "^1.1.4 || ^2",
     "drupal-composer/drupal-scaffold": "^2.6",
     "drupal/coder": "~8.2",
     "drupal/drupal-extension": "~4.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   },
   "require-dev": {
     "composer/installers": "^1.6",
-    "consolidation/robo": "^1.1.4 || ^2",
+    "consolidation/robo": "^1.4.11 || ^2",
     "drupal-composer/drupal-scaffold": "^2.6",
     "drupal/coder": "~8.2",
     "drupal/drupal-extension": "~4.0",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "drupal/drupal-extension": "~4.0",
     "drush/drush": "~10.2",
     "mikey179/vfsstream": "^1.6",
-    "phpunit/phpunit": "^7 || ^8",
+    "phpunit/phpunit": "^6.5 || ^7",
     "symfony/phpunit-bridge": "^3.4|^4.3",
     "zaporylie/composer-drupal-optimizations": "^1.1"
   },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "require": {
     "php": ">=7.1.0",
     "drupal/cas": "~1.5",
-    "drupal/core": "~8.8 || ~9"
+    "drupal/core": "^8.8.3 || ~9"
   },
   "require-dev": {
     "composer/installers": "^1.6",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "drupal/drupal-extension": "~4.0",
     "drush/drush": "~10.2",
     "mikey179/vfsstream": "^1.6",
-    "phpunit/phpunit": "^6.5 || ^7",
+    "phpunit/phpunit": "^7 || ^8",
     "symfony/phpunit-bridge": "^3.4|^4.3",
     "zaporylie/composer-drupal-optimizations": "^1.1"
   },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "drupal-composer/drupal-scaffold": "^2.6",
     "drupal/coder": "~8.2",
     "drupal/drupal-extension": "~4.0",
-    "drush/drush": "~10",
+    "drush/drush": "~10.2",
     "mikey179/vfsstream": "^1.6",
     "phpunit/phpunit": "^6.5 || ^7",
     "symfony/phpunit-bridge": "^3.4|^4.3",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "drupal-composer/drupal-scaffold": "^2.6",
     "drupal/coder": "~8.2",
     "drupal/drupal-extension": "~4.0",
-    "drush/drush": "^9.7",
+    "drush/drush": "~10",
     "mikey179/vfsstream": "^1.6",
     "phpunit/phpunit": "^6.5 || ^7",
     "symfony/phpunit-bridge": "^3.4|^4.3",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "drupal/coder": "~8.2",
     "drupal/drupal-extension": "~4.0",
     "drush/drush": "~10.2",
-    "mikey179/vfsstream": "^1.6",
+    "mikey179/vfsstream": "^1.6.7",
     "phpunit/phpunit": "^6.5 || ^7",
     "symfony/phpunit-bridge": "^3.4|^4.3",
     "zaporylie/composer-drupal-optimizations": "^1.1"

--- a/tests/travis-ci/run-test.sh
+++ b/tests/travis-ci/run-test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 # Run either PHPUnit tests or PHP_CodeSniffer tests on Travis CI, depending
 # on the passed in parameter.
 

--- a/tests/travis-ci/run-test.sh
+++ b/tests/travis-ci/run-test.sh
@@ -52,7 +52,7 @@ case "$1" in
         mysql_to_ramdisk
         ln -s $MODULE_DIR $DRUPAL_DIR/modules/contrib/cas_mock_server
         cd $MODULE_DIR
-        export SYMFONY_DEPRECATIONS_HELPER="/.*/"
+        export SYMFONY_DEPRECATIONS_HELPER=max[self]=0
         ./vendor/bin/phpunit
         exit $?
 esac

--- a/tests/travis-ci/run-test.sh
+++ b/tests/travis-ci/run-test.sh
@@ -52,6 +52,7 @@ case "$1" in
         mysql_to_ramdisk
         ln -s $MODULE_DIR $DRUPAL_DIR/modules/contrib/cas_mock_server
         cd $MODULE_DIR
+        export SYMFONY_DEPRECATIONS_HELPER="/.*/"
         ./vendor/bin/phpunit
         exit $?
 esac

--- a/tests/travis-ci/run-test.sh
+++ b/tests/travis-ci/run-test.sh
@@ -52,7 +52,7 @@ case "$1" in
         mysql_to_ramdisk
         ln -s $MODULE_DIR $DRUPAL_DIR/modules/contrib/cas_mock_server
         cd $MODULE_DIR
-        export SYMFONY_DEPRECATIONS_HELPER=max[self]=0
+        export SYMFONY_DEPRECATIONS_HELPER=max[self]=10
         ./vendor/bin/phpunit
         exit $?
 esac

--- a/tests/travis-ci/run-test.sh
+++ b/tests/travis-ci/run-test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 # Run either PHPUnit tests or PHP_CodeSniffer tests on Travis CI, depending
 # on the passed in parameter.
 
@@ -52,7 +50,6 @@ case "$1" in
         mysql_to_ramdisk
         ln -s $MODULE_DIR $DRUPAL_DIR/modules/contrib/cas_mock_server
         cd $MODULE_DIR
-        export SYMFONY_DEPRECATIONS_HELPER=max[self]=10
         ./vendor/bin/phpunit
         exit $?
 esac


### PR DESCRIPTION
This will ensure the module is tested both on Drupal 8 and Drupal 9.