### PR TITLE
Pass all query params back to the app

### DIFF
--- a/src/Form/LoginForm.php
+++ b/src/Form/LoginForm.php
@@ -108,7 +108,9 @@ class LoginForm extends FormBase {
     // Redirect to the application but append the 'ticket' to the query string.
     $options = UrlHelper::parse($form_state->getValue('service_url'));
     $options['query']['ticket'] = $service_ticket;
-    $form_state->setRedirectUrl(Url::fromUri($options['path'], $options));
+    $uri = $options['path'];
+    unset($options['path']);
+    $form_state->setRedirectUrl(Url::fromUri($uri, $options));
   }
 
   /**


### PR DESCRIPTION
* Removes a dependency to CAS module.
* Supports https://www.drupal.org/project/cas/issues/3150047 by
  allowing all query params to be passed back. In this case,
  we're interested in the 'destination' param.